### PR TITLE
Be able to configure number of redirects to follow

### DIFF
--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -2,7 +2,7 @@
 
 require "net/http"
 require "faraday"
-require "faraday_middleware"
+require "faraday_middleware/response/follow_redirects"
 
 require_relative "../faraday/logfmt_logger"
 require_relative "../faraday/url_size_limit"
@@ -13,6 +13,7 @@ module Twingly
   module HTTP
     class ConnectionError < StandardError; end
     class UrlSizeLimitExceededError < StandardError; end
+    class RedirectLimitReached < StandardError; end
     class Client # rubocop:disable Metrics/ClassLength
       DEFAULT_RETRYABLE_EXCEPTIONS = [
         Faraday::ConnectionFailed,
@@ -29,6 +30,7 @@ module Twingly
       DEFAULT_NUMBER_OF_RETRIES = 0
       DEFAULT_RETRY_INTERVAL = 1
       DEFAULT_MAX_URL_SIZE_BYTES = Float::INFINITY
+      DEFAULT_FOLLOW_REDIRECTS_LIMIT = 3
 
       attr_writer :http_timeout
       attr_writer :http_open_timeout
@@ -39,23 +41,14 @@ module Twingly
       attr_writer :request_id
       attr_writer :follow_redirects
 
+      attr_accessor :follow_redirects_limit
       attr_accessor :retryable_exceptions
 
       def initialize(logger:, base_user_agent:)
         @logger          = logger
         @base_user_agent = base_user_agent
-        @request_id      = nil
 
-        @http_timeout      = DEFAULT_HTTP_TIMEOUT
-        @http_open_timeout = DEFAULT_HTTP_OPEN_TIMEOUT
-
-        @retryable_exceptions = DEFAULT_RETRYABLE_EXCEPTIONS
-        @number_of_retries    = DEFAULT_NUMBER_OF_RETRIES
-        @retry_interval       = DEFAULT_RETRY_INTERVAL
-        @on_retry_callback    = nil
-        @follow_redirects     = false
-
-        @max_url_size_bytes = DEFAULT_MAX_URL_SIZE_BYTES
+        initialize_defaults
       end
 
       def get(url, params: {}, headers: {})
@@ -67,6 +60,19 @@ module Twingly
       end
 
       private
+
+      def initialize_defaults
+        @request_id             = nil
+        @http_timeout           = DEFAULT_HTTP_TIMEOUT
+        @http_open_timeout      = DEFAULT_HTTP_OPEN_TIMEOUT
+        @retryable_exceptions   = DEFAULT_RETRYABLE_EXCEPTIONS
+        @number_of_retries      = DEFAULT_NUMBER_OF_RETRIES
+        @retry_interval         = DEFAULT_RETRY_INTERVAL
+        @on_retry_callback      = nil
+        @follow_redirects       = false
+        @follow_redirects_limit = DEFAULT_FOLLOW_REDIRECTS_LIMIT
+        @max_url_size_bytes     = DEFAULT_MAX_URL_SIZE_BYTES
+      end
 
       # rubocop:disable Metrics/MethodLength
       def http_response_for(method, *args)
@@ -84,6 +90,8 @@ module Twingly
         raise ConnectionError
       rescue Faraday::UrlSizeLimit::LimitExceededError => error
         raise UrlSizeLimitExceededError, error.message
+      rescue FaradayMiddleware::RedirectLimitReached => error
+        raise RedirectLimitReached, error.message
       end
       # rubocop:enable all
 
@@ -131,7 +139,10 @@ module Twingly
                            headers: true,
                            bodies: true,
                            request_id: @request_id
-          faraday.use FaradayMiddleware::FollowRedirects if @follow_redirects
+          if @follow_redirects
+            faraday.use FaradayMiddleware::FollowRedirects,
+                        limit: @follow_redirects_limit
+          end
           faraday.adapter Faraday.default_adapter
           faraday.headers[:user_agent] = user_agent
         end

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -13,7 +13,7 @@ module Twingly
   module HTTP
     class ConnectionError < StandardError; end
     class UrlSizeLimitExceededError < StandardError; end
-    class RedirectLimitReached < StandardError; end
+    class RedirectLimitReachedError < StandardError; end
     class Client # rubocop:disable Metrics/ClassLength
       DEFAULT_RETRYABLE_EXCEPTIONS = [
         Faraday::ConnectionFailed,
@@ -91,7 +91,7 @@ module Twingly
       rescue Faraday::UrlSizeLimit::LimitExceededError => error
         raise UrlSizeLimitExceededError, error.message
       rescue FaradayMiddleware::RedirectLimitReached => error
-        raise RedirectLimitReached, error.message
+        raise RedirectLimitReachedError, error.message
       end
       # rubocop:enable all
 

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Twingly::HTTP::Client do
 
         it do
           expect { subject }
-            .to raise_error(Twingly::HTTP::RedirectLimitReached)
+            .to raise_error(Twingly::HTTP::RedirectLimitReachedError)
         end
       end
     end

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -99,40 +99,76 @@ RSpec.describe Twingly::HTTP::Client do
     end
 
     context "when given a host that redirects" do
-      let(:url)  { "http://this.redirects" }
-      let(:body) { "You were redirected here." }
+      let(:url) { "http://this.redirects" }
+      let(:stub_redirects) do
+        lambda do |start_url, base_redir_url, times|
+          times.times do |n|
+            redir_url = n == 0 ? start_url : "#{base_redir_url}#{n}"
 
-      before do
-        stub_request(:any, url)
-          .to_return(status: 302,
-                     headers: { "Location" => "http://redirected.here" })
-        stub_request(:any, "http://redirected.here")
-          .to_return(body: body)
-      end
+            stub_request(:any, redir_url)
+              .to_return(status: 302,
+                         headers: { "Location" => "#{base_redir_url}#{n + 1}" })
+          end
 
-      context "when not following redirects" do
-        before do
-          client.follow_redirects = false
-        end
-
-        it do
-          is_expected.to match(
-            headers: { "location" => "http://redirected.here" },
-            status: 302,
-            body: ""
-          )
+          stub_request(:any, "#{base_redir_url}#{times}").to_return(status: 200)
         end
       end
 
       context "when following redirects" do
         before do
           client.follow_redirects = true
+
+          stub_redirects.call(url, "http://redirect.", 1)
         end
 
         it do
           is_expected.to match(headers: {},
                                status: 200,
-                               body: body)
+                               body: "")
+        end
+      end
+
+      context "when not following redirects" do
+        before do
+          client.follow_redirects = false
+
+          stub_redirects.call(url, "http://redirect.", 1)
+        end
+
+        it do
+          is_expected.to match(headers: { "location" => "http://redirect.1" },
+                               status: 302,
+                               body: "")
+        end
+      end
+
+      context "when given a host that redirects many times" do
+        before do
+          redirects = 5
+          client.follow_redirects = true
+          client.follow_redirects_limit = redirects + 1
+
+          stub_redirects.call(url, "http://redirect.", redirects)
+        end
+
+        it do
+          is_expected.to match(headers: {},
+                               status: 200,
+                               body: "")
+        end
+      end
+
+      context "when given a host that redirects too many times" do
+        before do
+          client.follow_redirects = true
+          redirects = client.follow_redirects_limit + 1
+
+          stub_redirects.call(url, "http://redirect.", redirects)
+        end
+
+        it do
+          expect { subject }
+            .to raise_error(Twingly::HTTP::RedirectLimitReached)
         end
       end
     end


### PR DESCRIPTION
Also wrap the error that can be raised from Faraday.

Require `faraday_middleware/response/follow_redirects` directly, because
the error class `FaradayMiddleware::RedirectLimitReached` isn't loaded if
we haven't called `use FaradayMiddleware::FollowRedirects`.

The 👮🏻‍♂️ made me create `initialize_defaults`.