### PR TITLE
Green tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 Style/NumericLiterals:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
 before_install:
   - travis_retry docker pull shopify/toxiproxy
   - travis_retry docker run --net=host -d shopify/toxiproxy
-  - travis_retry gem update --system
+  # workaround https://github.com/rubygems/rubygems/issues/3030
+  - yes | travis_retry gem update --system
   - travis_retry gem install bundler
 before_script:
   - export RSPEC_SEED=$(ruby -e "print rand(0xFFFF)")

--- a/twingly-http.gemspec
+++ b/twingly-http.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "climate_control", "~> 0.1"
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "rspec", "~> 3"
-  s.add_development_dependency "rubocop", "~> 0.76"
+  s.add_development_dependency "rubocop", "~> 0.77.0"
   s.add_development_dependency "rubocop-rspec", "~> 1.36"
   s.add_development_dependency "toxiproxy", "~> 1.0"
   s.add_development_dependency "vcr", "~> 5.0"


### PR DESCRIPTION
Lock the RuboCop version so we control when we use a new version (CI runs regularly).

Updated to RuboCop 0.77, https://github.com/rubocop-hq/rubocop/releases/tag/v0.77.0