### PR TITLE
Allow newer versions of faraday

### DIFF
--- a/twingly-http.gemspec
+++ b/twingly-http.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = "~> 2.5"
 
-  s.add_dependency "faraday", "~> 1.0.1"
+  s.add_dependency "faraday", "~> 1", ">= 1.0.1"
   s.add_dependency "faraday_middleware", "~> 1.0.0"
 
   s.add_development_dependency "climate_control", "~> 0.1"


### PR DESCRIPTION
The new version suppresses the following warnings:

> /Users/pontus/.gem/ruby/2.7.1/gems/faraday-1.0.1/lib/faraday/dependency_loader.rb:21: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
> /Users/pontus/repos/twingly-http/lib/faraday/url_size_limit/middleware.rb:8: warning: The called method `initialize' is defined here

Close #10 