### PR TITLE
Require `"logger"`

### DIFF
--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "logger"
 require "net/http"
 require "faraday"
 require "faraday_middleware"


### PR DESCRIPTION
Got the following error in https://github.com/twingly/basil/pull/78:

```
gems/twingly-http-0.3.1/lib/twingly/http.rb:66:in `default_logger': uninitialized constant Twingly::HTTP::Client::Logger (NameError)
```

This bug was introduced in #13.