### PR TITLE
Extend client with `PUT`, `PATCH` and `DELETE` methods

### DIFF
--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -69,6 +69,10 @@ module Twingly
         http_response_for(:patch, url: url, body: body, headers: headers)
       end
 
+      def delete(url, params: {}, headers: {})
+        http_response_for(:delete, url: url, params: params, headers: headers)
+      end
+
       private
 
       def default_logger
@@ -90,6 +94,7 @@ module Twingly
 
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/CyclomaticComplexity
       def http_response_for(method, **args)
         response = case method
                    when :get
@@ -100,6 +105,8 @@ module Twingly
                      http_put_response(**args)
                    when :patch
                      http_patch_response(**args)
+                   when :delete
+                     http_delete_response(**args)
                    end
 
         Response.new(headers: response.headers.to_h,
@@ -169,6 +176,21 @@ module Twingly
           request.url(binary_url)
           request.headers.merge!(headers)
           request.body = body
+          request.options.timeout = @http_timeout
+          request.options.open_timeout = @http_open_timeout
+        end
+      end
+
+      def http_delete_response(url:, params:, headers:)
+        binary_url = url.dup.force_encoding(Encoding::BINARY)
+        http_client = create_http_client
+
+        headers = default_headers.merge(headers)
+
+        http_client.delete do |request|
+          request.url(binary_url)
+          request.params.merge!(params)
+          request.headers.merge!(headers)
           request.options.timeout = @http_timeout
           request.options.open_timeout = @http_open_timeout
         end

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -61,6 +61,10 @@ module Twingly
         http_response_for(:post, url: url, body: body, headers: headers)
       end
 
+      def put(url, body:, headers: {})
+        http_response_for(:put, url: url, body: body, headers: headers)
+      end
+
       private
 
       def default_logger
@@ -87,6 +91,8 @@ module Twingly
                      http_get_response(**args)
                    when :post
                      http_post_response(**args)
+                   when :put
+                     http_put_response(**args)
                    end
 
         Response.new(headers: response.headers.to_h,
@@ -123,6 +129,21 @@ module Twingly
         headers = default_headers.merge(headers)
 
         http_client.post do |request|
+          request.url(binary_url)
+          request.headers.merge!(headers)
+          request.body = body
+          request.options.timeout = @http_timeout
+          request.options.open_timeout = @http_open_timeout
+        end
+      end
+
+      def http_put_response(url:, body:, headers:)
+        binary_url = url.dup.force_encoding(Encoding::BINARY)
+        http_client = create_http_client
+
+        headers = default_headers.merge(headers)
+
+        http_client.put do |request|
           request.url(binary_url)
           request.headers.merge!(headers)
           request.body = body

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -92,22 +92,8 @@ module Twingly
         @max_url_size_bytes     = DEFAULT_MAX_URL_SIZE_BYTES
       end
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/CyclomaticComplexity
       def http_response_for(method, **args)
-        response = case method
-                   when :get
-                     http_get_response(**args)
-                   when :post
-                     http_post_response(**args)
-                   when :put
-                     http_put_response(**args)
-                   when :patch
-                     http_patch_response(**args)
-                   when :delete
-                     http_delete_response(**args)
-                   end
+        response = send("http_#{method}_response", **args)
 
         Response.new(headers: response.headers.to_h,
                      status: response.status,
@@ -119,7 +105,6 @@ module Twingly
       rescue FaradayMiddleware::RedirectLimitReached => error
         raise RedirectLimitReachedError, error.message
       end
-      # rubocop:enable all
 
       def http_get_response(url:, params:, headers:)
         binary_url = url.dup.force_encoding(Encoding::BINARY)

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -65,6 +65,10 @@ module Twingly
         http_response_for(:put, url: url, body: body, headers: headers)
       end
 
+      def patch(url, body:, headers: {})
+        http_response_for(:patch, url: url, body: body, headers: headers)
+      end
+
       private
 
       def default_logger
@@ -85,6 +89,7 @@ module Twingly
       end
 
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def http_response_for(method, **args)
         response = case method
                    when :get
@@ -93,6 +98,8 @@ module Twingly
                      http_post_response(**args)
                    when :put
                      http_put_response(**args)
+                   when :patch
+                     http_patch_response(**args)
                    end
 
         Response.new(headers: response.headers.to_h,
@@ -144,6 +151,21 @@ module Twingly
         headers = default_headers.merge(headers)
 
         http_client.put do |request|
+          request.url(binary_url)
+          request.headers.merge!(headers)
+          request.body = body
+          request.options.timeout = @http_timeout
+          request.options.open_timeout = @http_open_timeout
+        end
+      end
+
+      def http_patch_response(url:, body:, headers:)
+        binary_url = url.dup.force_encoding(Encoding::BINARY)
+        http_client = create_http_client
+
+        headers = default_headers.merge(headers)
+
+        http_client.patch do |request|
           request.url(binary_url)
           request.headers.merge!(headers)
           request.body = body

--- a/spec/fixtures/vcr_cassettes/delete_httpbin_org.yml
+++ b/spec/fixtures/vcr_cassettes/delete_httpbin_org.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://httpbin.org/delete
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Twingly::HTTP/1.0 (Release/unknown_heroku_release_version; Commit/unknown_heroku_slug_commit)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Nov 2021 09:56:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '471'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.9.0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\":
+        {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\":
+        \"gzip;q=1.0,deflate;q=0.6,identity;q=0.3\", \n    \"Host\": \"httpbin.org\",
+        \n    \"User-Agent\": \"Twingly::HTTP/1.0 (Release/unknown_heroku_release_version;
+        Commit/unknown_heroku_slug_commit)\", \n    \"X-Amzn-Trace-Id\": \"Root=1-619cbac1-4d4fed914eb525d9681a08f5\"\n
+        \ }, \n  \"json\": null, \n  \"origin\": \"80.252.185.203\", \n  \"url\":
+        \"https://httpbin.org/delete\"\n}\n"
+    http_version:
+  recorded_at: Tue, 23 Nov 2021 09:56:17 GMT
+recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/patch_httpbin_org.yml
+++ b/spec/fixtures/vcr_cassettes/patch_httpbin_org.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://httpbin.org/patch
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Twingly::HTTP/1.0 (Release/unknown_heroku_release_version; Commit/unknown_heroku_slug_commit)
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Nov 2021 13:58:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '556'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.9.0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\":
+        {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\":
+        \"gzip;q=1.0,deflate;q=0.6,identity;q=0.3\", \n    \"Content-Length\": \"0\",
+        \n    \"Content-Type\": \"application/x-www-form-urlencoded\", \n    \"Host\":
+        \"httpbin.org\", \n    \"User-Agent\": \"Twingly::HTTP/1.0 (Release/unknown_heroku_release_version;
+        Commit/unknown_heroku_slug_commit)\", \n    \"X-Amzn-Trace-Id\": \"Root=1-619ba213-335cd69c77cbb3347de2e074\"\n
+        \ }, \n  \"json\": null, \n  \"origin\": \"80.252.185.203\", \n  \"url\":
+        \"https://httpbin.org/patch\"\n}\n"
+    http_version:
+  recorded_at: Mon, 22 Nov 2021 13:58:43 GMT
+recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/put_httpbin_org.yml
+++ b/spec/fixtures/vcr_cassettes/put_httpbin_org.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://httpbin.org/put
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Twingly::HTTP/1.0 (Release/unknown_heroku_release_version; Commit/unknown_heroku_slug_commit)
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Nov 2021 07:33:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '554'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.9.0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\":
+        {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\":
+        \"gzip;q=1.0,deflate;q=0.6,identity;q=0.3\", \n    \"Content-Length\": \"0\",
+        \n    \"Content-Type\": \"application/x-www-form-urlencoded\", \n    \"Host\":
+        \"httpbin.org\", \n    \"User-Agent\": \"Twingly::HTTP/1.0 (Release/unknown_heroku_release_version;
+        Commit/unknown_heroku_slug_commit)\", \n    \"X-Amzn-Trace-Id\": \"Root=1-619b47bc-15737be00bd133aa5cd3414e\"\n
+        \ }, \n  \"json\": null, \n  \"origin\": \"80.252.185.203\", \n  \"url\":
+        \"https://httpbin.org/put\"\n}\n"
+    http_version:
+  recorded_at: Mon, 22 Nov 2021 07:33:16 GMT
+recorded_with: VCR 5.1.0

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -672,4 +672,54 @@ RSpec.describe Twingly::HTTP::Client do
       end
     end
   end
+
+  describe "#patch", vcr: Fixture.patch_httpbin_org do
+    include_examples "common HTTP behaviour for", :patch, "https://httpbin.org/patch"
+
+    let(:url) { "https://httpbin.org/patch" }
+
+    let(:patch_body)    {}
+    let(:patch_headers) { {} }
+    let(:request_response) do
+      client.patch(url, body: patch_body, headers: patch_headers)
+    end
+
+    describe "headers" do
+      let(:headers) do
+        {
+          "Content-Type" => "application/json",
+        }
+      end
+
+      before do
+        headers_in_body_lamba = lambda do |request|
+          { body: request.headers.to_json }
+        end
+
+        stub_request(:patch, url)
+          .to_return(&headers_in_body_lamba)
+      end
+
+      it "does request with specified headers" do
+        expect(JSON.parse(response.fetch(:body))).to include(patch_headers)
+      end
+    end
+
+    describe "body" do
+      let(:patch_body) { { "some" => "json" }.to_json }
+
+      before do
+        request_body_in_body_lamba = lambda do |request|
+          { body: request.body }
+        end
+
+        stub_request(:patch, url)
+          .to_return(&request_body_in_body_lamba)
+      end
+
+      it "does request with specified body" do
+        expect(response.fetch(:body)).to include(patch_body)
+      end
+    end
+  end
 end

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Twingly::HTTP::Client do
     }
   end
 
-  RSpec.shared_examples "common HTTP behaviour for" do |method|
+  RSpec.shared_examples "common HTTP behaviour for" do |method, stub_url|
     describe "User-Agent" do
       before do
         user_agent_in_body_lamba = lambda do |request|
@@ -182,7 +182,7 @@ RSpec.describe Twingly::HTTP::Client do
 
       context "when creating the connection" do
         before do
-          stub_request(:any, "example.org").to_timeout
+          stub_request(:any, stub_url).to_timeout
         end
 
         it "should raise exception" do
@@ -203,7 +203,7 @@ RSpec.describe Twingly::HTTP::Client do
 
       context "when reading the response" do
         before do
-          stub_request(:any, "example.org").to_raise(Net::ReadTimeout)
+          stub_request(:any, stub_url).to_raise(Net::ReadTimeout)
         end
 
         it "should raise exception" do
@@ -228,7 +228,7 @@ RSpec.describe Twingly::HTTP::Client do
       let(:exception) { SocketError }
 
       before do
-        stub_request(:any, "example.org")
+        stub_request(:any, stub_url)
           .to_raise(exception).then
           .to_return(body: body)
       end
@@ -486,7 +486,7 @@ RSpec.describe Twingly::HTTP::Client do
   end
 
   describe "#post", vcr: Fixture.post_example_org do
-    include_examples "common HTTP behaviour for", :post
+    include_examples "common HTTP behaviour for", :post, "example.org"
 
     let(:post_body)    {}
     let(:post_headers) { {} }
@@ -534,7 +534,7 @@ RSpec.describe Twingly::HTTP::Client do
   end
 
   describe "#get", vcr: Fixture.example_org do
-    include_examples "common HTTP behaviour for", :get
+    include_examples "common HTTP behaviour for", :get, "example.org"
 
     let(:request_response) do
       client.get(url)

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -622,4 +622,54 @@ RSpec.describe Twingly::HTTP::Client do
       end
     end
   end
+
+  describe "#put", vcr: Fixture.put_httpbin_org do
+    include_examples "common HTTP behaviour for", :put, "https://httpbin.org/put"
+
+    let(:url) { "https://httpbin.org/put" }
+
+    let(:put_body)    {}
+    let(:put_headers) { {} }
+    let(:request_response) do
+      client.put(url, body: put_body, headers: put_headers)
+    end
+
+    describe "headers" do
+      let(:headers) do
+        {
+          "Content-Type" => "application/json",
+        }
+      end
+
+      before do
+        headers_in_body_lamba = lambda do |request|
+          { body: request.headers.to_json }
+        end
+
+        stub_request(:put, url)
+          .to_return(&headers_in_body_lamba)
+      end
+
+      it "does request with specified headers" do
+        expect(JSON.parse(response.fetch(:body))).to include(put_headers)
+      end
+    end
+
+    describe "body" do
+      let(:put_body) { { "some" => "json" }.to_json }
+
+      before do
+        request_body_in_body_lamba = lambda do |request|
+          { body: request.body }
+        end
+
+        stub_request(:put, url)
+          .to_return(&request_body_in_body_lamba)
+      end
+
+      it "does request with specified body" do
+        expect(response.fetch(:body)).to include(put_body)
+      end
+    end
+  end
 end

--- a/spec/spec_help/fixture.rb
+++ b/spec/spec_help/fixture.rb
@@ -29,6 +29,13 @@ class Fixture
     }
   end
 
+  def self.delete_httpbin_org(ignore_params: [])
+    {
+      cassette_name: "delete_httpbin_org",
+      match_requests_on: [:method, custom_uri_matcher(ignore_params)],
+    }
+  end
+
   def self.custom_uri_matcher(ignore_params)
     VCR.request_matchers.uri_without_params(*ignore_params)
   end

--- a/spec/spec_help/fixture.rb
+++ b/spec/spec_help/fixture.rb
@@ -22,6 +22,13 @@ class Fixture
     }
   end
 
+  def self.patch_httpbin_org(ignore_params: [])
+    {
+      cassette_name: "patch_httpbin_org",
+      match_requests_on: [:method, custom_uri_matcher(ignore_params)],
+    }
+  end
+
   def self.custom_uri_matcher(ignore_params)
     VCR.request_matchers.uri_without_params(*ignore_params)
   end

--- a/spec/spec_help/fixture.rb
+++ b/spec/spec_help/fixture.rb
@@ -15,6 +15,13 @@ class Fixture
     }
   end
 
+  def self.put_httpbin_org(ignore_params: [])
+    {
+      cassette_name: "put_httpbin_org",
+      match_requests_on: [:method, custom_uri_matcher(ignore_params)],
+    }
+  end
+
   def self.custom_uri_matcher(ignore_params)
     VCR.request_matchers.uri_without_params(*ignore_params)
   end


### PR DESCRIPTION
`PUT` and `PATCH` were implemented in the same way as `POST` and `DELETE` was implemented like `GET` due to their similar client-side behaviour.

Close #24.