### PR TITLE
Add `final_url` to response

### DIFF
--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -97,7 +97,8 @@ module Twingly
 
         Response.new(headers: response.headers.to_h,
                      status: response.status,
-                     body: response.body)
+                     body: response.body,
+                     final_url: response.env.url.to_s)
       rescue *(@retryable_exceptions + TIMEOUT_EXCEPTIONS)
         raise ConnectionError
       rescue Faraday::UrlSizeLimit::LimitExceededError => error
@@ -258,13 +259,16 @@ module Twingly
       attr_reader :headers
       attr_reader :status
       attr_reader :body
+      attr_reader :final_url
 
       def initialize(headers: nil,
                      status: nil,
-                     body: nil)
+                     body: nil,
+                     final_url: nil)
         @headers       = headers
         @status        = status
         @body          = body
+        @final_url     = final_url
       end
     end
   end

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe Twingly::HTTP::Client do
 
   subject(:response) do
     {
-      headers: request_response.headers,
-      status:  request_response.status,
-      body:    request_response.body,
+      headers:   request_response.headers,
+      status:    request_response.status,
+      body:      request_response.body,
+      final_url: request_response.final_url,
     }
   end
 
@@ -124,7 +125,8 @@ RSpec.describe Twingly::HTTP::Client do
         it do
           is_expected.to match(headers: {},
                                status: 200,
-                               body: "")
+                               body: "",
+                               final_url: "http://redirect.1")
         end
       end
 
@@ -138,7 +140,8 @@ RSpec.describe Twingly::HTTP::Client do
         it do
           is_expected.to match(headers: { "location" => "http://redirect.1" },
                                status: 302,
-                               body: "")
+                               body: "",
+                               final_url: url)
         end
       end
 
@@ -154,7 +157,8 @@ RSpec.describe Twingly::HTTP::Client do
         it do
           is_expected.to match(headers: {},
                                status: 200,
-                               body: "")
+                               body: "",
+                               final_url: "http://redirect.5")
         end
       end
 
@@ -247,7 +251,8 @@ RSpec.describe Twingly::HTTP::Client do
         it do
           is_expected.to match(headers: {},
                                status: 200,
-                               body: body)
+                               body: body,
+                               final_url: url)
         end
 
         it 'calls the "on retry" callback' do
@@ -271,7 +276,8 @@ RSpec.describe Twingly::HTTP::Client do
           it do
             is_expected.to match(headers: {},
                                  status: 200,
-                                 body: body)
+                                 body: body,
+                                 final_url: url)
           end
 
           it 'calls the "on retry" callback' do
@@ -543,7 +549,8 @@ RSpec.describe Twingly::HTTP::Client do
     it do
       is_expected.to match(headers: be_an_instance_of(Hash),
                            status: 200,
-                           body: match(/Example Domain/))
+                           body: match(/Example Domain/),
+                           final_url: url)
     end
 
     # https://github.com/lostisland/faraday/pull/513#issuecomment-254794047
@@ -554,7 +561,8 @@ RSpec.describe Twingly::HTTP::Client do
       it do
         is_expected.to match(headers: be_an_instance_of(Hash),
                              status: 200,
-                             body: match(/Example Domain/))
+                             body: match(/Example Domain/),
+                             final_url: url)
       end
     end
 
@@ -735,7 +743,8 @@ RSpec.describe Twingly::HTTP::Client do
     it do
       is_expected.to match(headers: be_an_instance_of(Hash),
                            status: 200,
-                           body: be_an_instance_of(String))
+                           body: be_an_instance_of(String),
+                           final_url: url)
     end
 
     describe "headers" do


### PR DESCRIPTION
This new addition makes it possible to determine the URL that the client ends up on in case of one or more redirects. When using the `follow_redirects` option before, the final URL was found but not accessible from the `Response` object. Faraday's `Env.url` contains the URL of the final request [1].

The specs were updated accordingly.

[1]: https://www.rubydoc.info/gems/faraday/Faraday/Env#url-instance_method