### PR TITLE
Adjust user_agent creation

### DIFF
--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -46,9 +46,10 @@ module Twingly
       attr_accessor :logger
       attr_accessor :retryable_exceptions
 
-      def initialize(base_user_agent:, logger: default_logger)
+      def initialize(base_user_agent:, logger: default_logger, user_agent: nil)
         @base_user_agent = base_user_agent
         @logger          = logger
+        @user_agent      = user_agent
 
         initialize_defaults
       end
@@ -232,7 +233,7 @@ module Twingly
       end
 
       def user_agent
-        format(
+        @user_agent || format(
           "%<base>s (Release/%<release>s; Commit/%<commit>s)",
           base: @base_user_agent,
           release: Heroku.release_version,


### PR DESCRIPTION
This new addition allows the user to set a specific user_agent for the client. 

I added a new parameter to the initialize, so that if we'd want to use a specific user_agent it would be possible. This parameter has a default as well, so that no changes would have to be made in older projects unless a specific user_agent is needed.

The specs have also been updated accordingly. 