### PR TITLE
Make it possible to configure max response body size

### DIFF
--- a/lib/faraday/response_body_size_limit.rb
+++ b/lib/faraday/response_body_size_limit.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "response_body_size_limit/middleware"
+
+module Faraday
+  module ResponseBodySizeLimit
+  end
+end

--- a/lib/faraday/response_body_size_limit/middleware.rb
+++ b/lib/faraday/response_body_size_limit/middleware.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Faraday
+  module ResponseBodySizeLimit
+    class LimitExceededError < StandardError; end
+
+    class Middleware < Faraday::Middleware
+      def initialize(app, max_size_bytes:)
+        super(app)
+
+        @max_size_bytes = max_size_bytes
+      end
+
+      def call(env) # rubocop:disable Metrics/MethodLength
+        response_body_size = 0
+        accumulated_body   = + ""
+
+        env.request.on_data = proc do |chunk, _|
+          response_body_size += chunk.bytesize
+          accumulated_body   << chunk
+
+          if response_body_size > @max_size_bytes
+            raise LimitExceededError,
+                  "Response body too large, exceeced the configured max size of #{@max_size_bytes} bytes."
+          end
+        end
+
+        @app.call(env).on_complete do |response_env|
+          response_env.body = accumulated_body
+        end
+      end
+    end
+  end
+end
+
+Faraday::Request.register_middleware(
+  response_body_size_limit: Faraday::ResponseBodySizeLimit::Middleware
+)

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -440,6 +440,35 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
       end
     end
 
+    context "when a maximum response body size is set" do
+      let(:max_response_body_size_bytes) { 64 }
+
+      before do
+        client.max_response_body_size_bytes = max_response_body_size_bytes
+
+        stub_request(:any, url).to_return(body: body)
+      end
+
+      context "when response body is below limit" do
+        let(:body) { "a" * max_response_body_size_bytes }
+
+        before { request_response }
+
+        it "returns the response with the expected body" do
+          expect(response.fetch(:body)).to eq(body)
+        end
+      end
+
+      context "when response body is above limit" do
+        let(:body) { "a" * (max_response_body_size_bytes + 1) }
+
+        it "raises an error" do
+          expect { request_response }
+            .to raise_error(Twingly::HTTP::ResponseBodySizeLimitExceededError)
+        end
+      end
+    end
+
     context "with unreliable hosts" do
       let(:example_timeout) { 1.0 }
 


### PR DESCRIPTION
Added a Faraday middleware which streams the body, counting the number of bytes it receives. If the body exceeds the configured maximum size (using the `max_response_body_size_bytes:` argument), it raises an error.

close #21