### PR TITLE
Fix bug causing the bodies of all requests to be concatenated

### DIFF
--- a/lib/faraday/response_body_size_limit/middleware.rb
+++ b/lib/faraday/response_body_size_limit/middleware.rb
@@ -33,6 +33,6 @@ module Faraday
   end
 end
 
-Faraday::Request.register_middleware(
+Faraday::Response.register_middleware(
   response_body_size_limit: Faraday::ResponseBodySizeLimit::Middleware
 )

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -200,8 +200,6 @@ module Twingly
                           exceptions: @retryable_exceptions,
                           methods: [], # empty [] forces Faraday to run retry_if
                           retry_if: retry_if
-          faraday.request :response_body_size_limit,
-                          max_size_bytes: @max_response_body_size_bytes
           faraday.response :logfmt_logger, @logger.dup,
                            headers: true,
                            bodies: true,
@@ -210,6 +208,8 @@ module Twingly
             faraday.use FaradayMiddleware::FollowRedirects,
                         limit: @follow_redirects_limit
           end
+          faraday.request :response_body_size_limit,
+                          max_size_bytes: @max_response_body_size_bytes
           faraday.adapter Faraday.default_adapter
           faraday.headers[:user_agent] = user_agent
         end

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -208,8 +208,8 @@ module Twingly
             faraday.use FaradayMiddleware::FollowRedirects,
                         limit: @follow_redirects_limit
           end
-          faraday.request :response_body_size_limit,
-                          max_size_bytes: @max_response_body_size_bytes
+          faraday.response :response_body_size_limit,
+                           max_size_bytes: @max_response_body_size_bytes
           faraday.adapter Faraday.default_adapter
           faraday.headers[:user_agent] = user_agent
         end

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -133,10 +133,11 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
 
             stub_request(:any, redir_url)
               .to_return(status: 302,
-                         headers: { "Location" => "#{base_redir_url}#{n + 1}" })
+                         headers: { "Location" => "#{base_redir_url}#{n + 1}" },
+                         body: "redirect...")
           end
 
-          stub_request(:any, "#{base_redir_url}#{times}").to_return(status: 200)
+          stub_request(:any, "#{base_redir_url}#{times}").to_return(status: 200, body: "finished!")
         end
       end
 
@@ -150,8 +151,12 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
         it do
           is_expected.to match(headers: {},
                                status: 200,
-                               body: "",
+                               body: "finished!",
                                final_url: "http://redirect.1")
+        end
+
+        it "only returns the body of the final request" do
+          expect(response.fetch(:body)).to eq("finished!")
         end
       end
 
@@ -165,7 +170,7 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
         it do
           is_expected.to match(headers: { "location" => "http://redirect.1" },
                                status: 302,
-                               body: "",
+                               body: "redirect...",
                                final_url: url)
         end
       end
@@ -182,7 +187,7 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
         it do
           is_expected.to match(headers: {},
                                status: 200,
-                               body: "",
+                               body: "finished!",
                                final_url: "http://redirect.5")
         end
       end


### PR DESCRIPTION
When I added the middleware that checks the response body size in https://github.com/twingly/twingly-http/pull/32, I introduced a bug where the response bodies for all requests in a redirect "chain" gets included in the body returned in the `Twingly::HTTP::Response` object.

What I did here was to move the middleware after the `FollowRedirects` middleware, to ensure we run the middleware on each request, instead of handling all response body chunks at once.

The test I added here (along with some other existing tests), would fail with the following error before this fix:

```
    1) Twingly::HTTP::Client#post when given a host that redirects when following redirects only returns the body of the final request
      Failure/Error: expect(response.fetch(:body)).to eq("finished!")

        expected: "finished!"
              got: "redirect...finished!"

        (compared using ==)
      Shared Example Group: "common HTTP behaviour for" called from ./spec/lib/twingly/http_spec.rb:554
      # ./spec/lib/twingly/http_spec.rb:159:in `block (5 levels) in <top (required)>'
```