### PR TITLE
Add proxy support to HTTP Client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gemspec
 
 group :development, :test do
   gem "climate_control", "~> 0.1"
+  gem "rack", "~> 3.1"
+  gem "rack-proxy", "~> 0.7.7"
+  gem "rackup", "~> 2.2"
   gem "rake", "~> 12"
   gem "rspec", "~> 3"
   gem "rubocop", "~> 1.64.1"
@@ -13,4 +16,5 @@ group :development, :test do
   gem "toxiproxy", "~> 1.0"
   gem "vcr", "~> 5.0"
   gem "webmock", "~> 3.7"
+  gem "webrick", "~> 1.9"
 end

--- a/lib/twingly/http.rb
+++ b/lib/twingly/http.rb
@@ -50,10 +50,11 @@ module Twingly
       attr_accessor :logger
       attr_accessor :retryable_exceptions
 
-      def initialize(base_user_agent:, logger: default_logger, user_agent: nil)
+      def initialize(base_user_agent:, logger: default_logger, user_agent: nil, proxy: nil)
         @base_user_agent = base_user_agent
         @logger          = logger
         @user_agent      = user_agent
+        @proxy           = proxy
 
         initialize_defaults
       end
@@ -212,6 +213,7 @@ module Twingly
                            max_size_bytes: @max_response_body_size_bytes
           faraday.adapter Faraday.default_adapter
           faraday.headers[:user_agent] = user_agent
+          faraday.proxy = @proxy if @proxy
         end
       end
 

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -689,11 +689,9 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
       end
     end
 
-    fdescribe "proxy" do
-      let(:test_url) { "http://example.com" }
-
-      context "when a proxy is set" do
-        let(:proxy_url) { "http://localhost:1080" }
+    describe "proxy" do
+      context "when a proxy is provided" do
+        let(:proxy_url) { "http://127.0.0.1:8080" }
         let(:proxy_client) do
           described_class.new(
             base_user_agent: base_user_agent,
@@ -703,22 +701,10 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
           )
         end
 
-        before(:all) do
-          let(:toxiproxy) { Toxiproxy.new(host: "localhost", port: 8474) }
-          let(:proxy) { toxiproxy.create("proxy", listen: "localhost:1080", upstream: "https://example.com") }
-        end
+        it "sets the proxy" do
+          connection = proxy_client.send(:create_http_client)
 
-        after(:all) do
-          proxy.delete
-          toxiproxy.close
-        end
-
-        it "sets the proxy URL correctly in the Twingly HTTP client" do
-          allow(proxy_client).to receive(proxy).and_return(proxy_url)
-          response = proxy_client.get("https://example.com")
-
-          expect(proxy_client.proxy).to eq(proxy_url)
-          expect(response.status).to eq(200)
+          expect(connection.proxy.uri.to_s).to eq(proxy_url)
         end
       end
     end

--- a/spec/lib/twingly/http_spec.rb
+++ b/spec/lib/twingly/http_spec.rb
@@ -537,23 +537,19 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
 
   RSpec.shared_examples "verifies proxy functionality" do
     context "when a proxy is provided" do
-      let(:proxy_pid_and_url) { HttpTestServer.spawn("proxy_server") }
-      let(:proxy_pid) { proxy_pid_and_url[0] }
-      let(:proxy_url) { proxy_pid_and_url[1] }
-      let(:target_pid_and_url) { HttpTestServer.spawn("echoed_headers_in_body") }
-      let(:target_pid) { target_pid_and_url[0] }
-      let(:target_url) { target_pid_and_url[1] }
+      let(:proxy_server)  { HttpTestServer.spawn("proxy_server") }
+      let(:target_server) { HttpTestServer.spawn("echoed_headers_in_body") }
       let(:client) do
         described_class.new(
           base_user_agent: base_user_agent,
-          proxy: proxy_url
+          proxy: proxy_server.url
         )
       end
-      let(:url) { target_url }
+      let(:url) { target_server.url }
 
       after do
-        HttpTestServer.stop(proxy_pid)
-        HttpTestServer.stop(target_pid)
+        HttpTestServer.stop(proxy_server.pid)
+        HttpTestServer.stop(target_server.pid)
       end
 
       it "routes requests through the proxy", vcr: false do
@@ -633,6 +629,7 @@ RSpec.describe Twingly::HTTP::Client do # rubocop:disable RSpec/SpecFilePathForm
   describe "#get", vcr: Fixture.example_org do
     include_examples "common HTTP behaviour for", :get, "example.org"
     include_examples "verifies proxy functionality"
+
     let(:request_response) do
       client.get(url)
     end

--- a/spec/rack_servers/echoed_headers_in_body.ru
+++ b/spec/rack_servers/echoed_headers_in_body.ru
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "json"
+
+run lambda { |env|
+  request_headers = env.select { |k, _v| k.start_with? "HTTP_" }
+
+  [200, { "content-type" => "application/json" }, [request_headers.to_json]]
+}

--- a/spec/rack_servers/proxy_server.ru
+++ b/spec/rack_servers/proxy_server.ru
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rack/proxy"
+
+class TestProxy < Rack::Proxy
+  def rewrite_env(env)
+    env["HTTP_X_PROXIED_BY"] = "test-proxy"
+    env
+  end
+end
+
+run TestProxy.new

--- a/spec/spec_help/http_helpers.rb
+++ b/spec/spec_help/http_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module HttpHelpers
+  def with_real_http_connections
+    original_cassette = VCR.eject_cassette
+    VCR.turn_off!
+    WebMock.allow_net_connect!
+
+    yield
+  ensure
+    WebMock.disable_net_connect!
+    VCR.turn_on!
+    VCR.insert_cassette(original_cassette.name) if original_cassette
+  end
+end

--- a/spec/spec_help/http_test_server.rb
+++ b/spec/spec_help/http_test_server.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+module HttpTestServer
+  module_function
+
+  def spawn_server_with_echoed_headers_in_body
+    spawn("echoed_headers_in_body")
+  end
+
+  def spawn(server_name, env: {}) # rubocop:disable Metrics/MethodLength
+    ip_address = PortProber.localhost
+    port = PortProber.random(ip_address)
+    url = "http://#{ip_address}:#{port}"
+    server = "spec/rack_servers/#{server_name}.ru"
+    command = "bundle exec rackup --quiet --port #{port} #{server}"
+
+    puts "starting HTTP test server: #{command}"
+    pid = fork do
+      $stdout.reopen File::NULL
+      $stderr.reopen File::NULL
+      exec env, command
+    end
+
+    Timeout.timeout(10.0) do
+      sleep 0.05 until started?(pid) && PortProber.port_open?(ip_address, port)
+    end
+
+    [pid, url]
+  end
+
+  def stop(pid)
+    Process.kill(:TERM, pid)
+    Process.wait(pid)
+  end
+
+  def started?(pid)
+    Process.getpgid(pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+end

--- a/spec/spec_help/http_test_server.rb
+++ b/spec/spec_help/http_test_server.rb
@@ -5,6 +5,8 @@ require "timeout"
 module HttpTestServer
   module_function
 
+  TestServer = Struct.new(:pid, :url)
+
   def spawn(server_name, env: {}) # rubocop:disable Metrics/MethodLength
     ip_address = PortProber.localhost
     port = PortProber.random(ip_address)
@@ -23,7 +25,7 @@ module HttpTestServer
       sleep 0.05 until started?(pid) && PortProber.port_open?(ip_address, port)
     end
 
-    [pid, url]
+    TestServer.new(pid, url)
   end
 
   def stop(pid)

--- a/spec/spec_help/http_test_server.rb
+++ b/spec/spec_help/http_test_server.rb
@@ -5,10 +5,6 @@ require "timeout"
 module HttpTestServer
   module_function
 
-  def spawn_server_with_echoed_headers_in_body
-    spawn("echoed_headers_in_body")
-  end
-
   def spawn(server_name, env: {}) # rubocop:disable Metrics/MethodLength
     ip_address = PortProber.localhost
     port = PortProber.random(ip_address)

--- a/spec/spec_help/port_prober.rb
+++ b/spec/spec_help/port_prober.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "socket"
+require "timeout"
+
+module PortProber
+  module_function
+
+  def random(host)
+    server = TCPServer.new(host, 0)
+    port   = server.addr[1]
+
+    port
+  ensure
+    server&.close
+  end
+
+  def port_open?(ip_address, port)
+    Timeout.timeout(0.5) do
+      TCPSocket.new(ip_address, port).close
+      true
+    end
+  rescue StandardError
+    false
+  end
+
+  def localhost
+    info = Socket.getaddrinfo("localhost",
+                              80,
+                              Socket::AF_INET,
+                              Socket::SOCK_STREAM)
+
+    raise "unable to translate 'localhost' for TCP + IPv4" if info.empty?
+
+    info[0][3]
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,25 +14,10 @@ require_relative "../lib/twingly/http"
 
 require_relative "spec_help/env_helper"
 require_relative "spec_help/fixture"
+require_relative "spec_help/http_helpers"
 require_relative "spec_help/test_logger"
 require_relative "spec_help/toxiproxy_config"
-require_relative "spec_help/http_test_server"
 require_relative "spec_help/port_prober"
-
-module HttpHelpers
-  def with_real_http_connections
-    original_cassette = VCR.current_cassette
-    VCR.eject_cassette if original_cassette
-    VCR.turn_off!
-    WebMock.allow_net_connect!
-
-    yield
-  ensure
-    WebMock.disable_net_connect!
-    VCR.turn_on!
-    VCR.insert_cassette(original_cassette.name) if original_cassette
-  end
-end
 
 # Start with a clean slate, destroy all proxies if any
 Toxiproxy.all.destroy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ require_relative "spec_help/env_helper"
 require_relative "spec_help/fixture"
 require_relative "spec_help/test_logger"
 require_relative "spec_help/toxiproxy_config"
+require_relative "spec_help/http_test_server"
+require_relative "spec_help/port_prober"
 
 # Start with a clean slate, destroy all proxies if any
 Toxiproxy.all.destroy


### PR DESCRIPTION
This PR adds the ability to route HTTP requests through a proxy server.

### Changes
- Add `proxy` parameter to `Twingly::HTTP::Client` initialization
- Configure Faraday connection to use the specified proxy

### Tests
- Start Rack-based proxy and target servers to verify that requests are properly routed through the proxy